### PR TITLE
fix: 결과저장시 타임라인 없으면 생기는 에러 처리

### DIFF
--- a/src/main/java/jungle/krafton/AIInterviewMate/jwt/CustomOAuth2UserService.java
+++ b/src/main/java/jungle/krafton/AIInterviewMate/jwt/CustomOAuth2UserService.java
@@ -99,6 +99,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public List<Question> getQuestionList(QuestionBox questionBox) throws IOException {
         BufferedReader reader = new BufferedReader(
                 new FileReader("./src/main/resources/InitQuestion.txt") // TODO: EC2 서버에 배포 시 파일 경로 변경
+//                new FileReader("./InitQuestion.txt") // TODO: EC2 서버에 배포 시 파일 경로 변경
         );
 
         List<Question> questions = new ArrayList<>();

--- a/src/main/java/jungle/krafton/AIInterviewMate/service/ResultService.java
+++ b/src/main/java/jungle/krafton/AIInterviewMate/service/ResultService.java
@@ -117,7 +117,7 @@ public class ResultService {
     }
 
     private String convertTimelinesToString(List<String> timelines) {
-        if (timelines == null) {
+        if (timelines == null || timelines.isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
## Describe your changes
fix: 결과저장시 타임라인 없으면 생기는 에러 처리

## Issue number and link
#136 